### PR TITLE
Added support for rejected promises

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,10 @@ export class InversifyExpressServer  {
                     if (value && !res.headersSent) {
                         res.send(value);
                     }
-                });
+                })
+                    .catch((error: any) => {
+                        next(error);
+                    });
 
             } else if (result && !res.headersSent) {
                 res.send(result);

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -46,6 +46,24 @@ describe("Integration Tests:", () => {
                 .expect(200, "GET", done);
         });
 
+        it("should work for async controller methods that fails", (done) => {
+            @injectable()
+            @Controller("/")
+            class TestController {
+                @Get("/") public getTest(req: express.Request, res: express.Response) {
+                    return new Promise(((resolve, reject) => {
+                        setTimeout(reject, 100, "GET");
+                    }));
+                }
+            }
+            kernel.bind<interfaces.Controller>("Controller").to(TestController).whenTargetNamed("TestController");
+
+            server = new InversifyExpressServer(kernel);
+            request(server.build())
+                .get("/")
+                .expect(500, done);
+        });
+
 
         it ("should work for methods which call next()", (done) => {
             @injectable()


### PR DESCRIPTION
This PR adds support for rejected promises so that default/custom error handler middleware can fulfill the request. 
