### PR TITLE
Rename all decorators to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please refer to the [InversifyJS documentation](https://github.com/inversify/Inv
 ## The Basics
 
 ### Step 1: Decorate your controllers
-To use a class as a "controller" for your express app, simply add the `@Controller` decorator to the class. Similarly, decorate methods of the class to serve as request handlers.
+To use a class as a "controller" for your express app, simply add the `@controller` decorator to the class. Similarly, decorate methods of the class to serve as request handlers.
 The following example will declare a controller that responds to `GET /foo'.
 
 ```ts
@@ -35,24 +35,24 @@ import * as express from 'express';
 import { interfaces, Controller, Get, Post, Delete } from 'inversify-express-utils';
 import { injectable, inject } from 'inversify';
 
-@Controller('/foo')
+@controller('/foo')
 @injectable()
 export class FooController implements interfaces.Controller {
 
     constructor( @inject('FooService') private fooService: FooService ) {}
 
-    @Get('/')
+    @httpGet('/')
     private index(req: express.Request, res: express.Response, next: express.NextFunction): string {
         return this.fooService.get(req.query.id);
     }
 
-    @Get('/')
-    private list(@QueryParams('start') start: number, @QueryParams('count') cound: number): string {
+    @httpGet('/')
+    private list(@queryParams('start') start: number, @queryParams('count') cound: number): string {
         return this.fooService.get(start, count);
     }
 
-    @Post('/')
-    private async create(@Response() res: express.Response) {
+    @httpPost('/')
+    private async create(@response() res: express.Response) {
         try {
             await this.fooService.create(req.body)
             res.sendStatus(201)
@@ -61,8 +61,8 @@ export class FooController implements interfaces.Controller {
         }
     }
 
-    @Delete('/:id')
-    private delete(@RequestParam("id") id: string, @Response() res: express.Response): Promise<void> {
+    @httpDelete('/:id')
+    private delete(@requestParam("id") id: string, @response() res: express.Response): Promise<void> {
         return this.fooService.delete(id)
             .then(() => res.sendStatus(204))
             .catch((err) => {
@@ -181,40 +181,40 @@ let server = new InversifyExpressServer(container, null, null, app);
 
 ## Decorators
 
-### `@Controller(path, [middleware, ...])`
+### `@controller(path, [middleware, ...])`
 
 Registers the decorated class as a controller with a root path, and optionally registers any global middleware for this controller.
 
-### `@Method(method, path, [middleware, ...])`
+### `@httpMethod(method, path, [middleware, ...])`
 
 Registers the decorated controller method as a request handler for a particular path and method, where the method name is a valid express routing method.
 
 ### `@SHORTCUT(path, [middleware, ...])`
 
-Shortcut decorators which are simply wrappers for `@Method`. Right now these include `@Get`, `@Post`, `@Put`, `@Patch`, `@Head`, `@Delete`, and `@All`. For anything more obscure, use `@Method` (Or make a PR :smile:).
+Shortcut decorators which are simply wrappers for `@httpMethod`. Right now these include `@httpGet`, `@httpPost`, `@httpPut`, `@httpPatch`, `@httpHead`, `@httpDelete`, and `@All`. For anything more obscure, use `@httpMethod` (Or make a PR :smile:).
 
-### `@Request()`
+### `@request()`
     Binds a method parameter to the request object.
 
-### `@Response()`
+### `@response()`
     Binds a method parameter to the response object.
 
-### `@RequestParam(name?: string)`
+### `@requestParam(name?: string)`
     Binds a method parameter to request.params object or to a specific parameter if a name is passed.
     
-### `@QueryParam(name?: string)`
+### `@queryParam(name?: string)`
     Binds a method parameter to request.query or to a specific query parameter if a name is passed.
 
-### `@RequestBody(name?: string)`
+### `@requestBody(name?: string)`
     Binds a method parameter to request.body or to a specific body property if a name is passed.
 
-### `@RequestHeaders(name?: string)`
+### `@requestHeaders(name?: string)`
     Binds a method parameter to the request headers.
 
-### `@Cookies()`
+### `@cookies()`
     Binds a method parameter to the request cookies.
 
-### `@Next()`
+### `@next()`
     Binds a method parameter to the next() function.
 
 ## Examples

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -2,42 +2,42 @@ import * as express from "express";
 import { interfaces } from "./interfaces";
 import { METADATA_KEY, PARAMETER_TYPE } from "./constants";
 
-export function Controller(path: string, ...middleware: interfaces.Middleware[]) {
+export function controller(path: string, ...middleware: interfaces.Middleware[]) {
     return function (target: any) {
         let metadata: interfaces.ControllerMetadata = {path, middleware, target};
         Reflect.defineMetadata(METADATA_KEY.controller, metadata, target);
     };
 }
 
-export function All   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("all",    path, ...middleware);
+export function all   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("all",    path, ...middleware);
 }
 
-export function Get   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("get",    path, ...middleware);
+export function httpGet   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("get",    path, ...middleware);
 }
 
-export function Post  (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("post",   path, ...middleware);
+export function httpPost  (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("post",   path, ...middleware);
 }
 
-export function Put   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("put",    path, ...middleware);
+export function httpPut   (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("put",    path, ...middleware);
 }
 
-export function Patch (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("patch",  path, ...middleware);
+export function httpPatch (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("patch",  path, ...middleware);
 }
 
-export function Head  (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("head",   path, ...middleware);
+export function httpHead  (path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("head",   path, ...middleware);
 }
 
-export function Delete(path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
-    return Method("delete", path, ...middleware);
+export function httpDelete(path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+    return httpMethod("delete", path, ...middleware);
 }
 
-export function Method(method: string, path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
+export function httpMethod(method: string, path: string, ...middleware: interfaces.Middleware[]): interfaces.HandlerDecorator {
     return function (target: any, key: string, value: any) {
         let metadata: interfaces.ControllerMethodMetadata = {path, middleware, method, target, key};
         let metadataList: interfaces.ControllerMethodMetadata[] = [];
@@ -52,23 +52,23 @@ export function Method(method: string, path: string, ...middleware: interfaces.M
     };
 }
 
-export const Request = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);
-export const Response = paramDecoratorFactory(PARAMETER_TYPE.RESPONSE);
-export const RequestParam = paramDecoratorFactory(PARAMETER_TYPE.PARAMS);
-export const QueryParam = paramDecoratorFactory(PARAMETER_TYPE.QUERY);
-export const RequestBody = paramDecoratorFactory(PARAMETER_TYPE.BODY);
-export const RequestHeaders = paramDecoratorFactory(PARAMETER_TYPE.HEADERS);
-export const Cookies = paramDecoratorFactory(PARAMETER_TYPE.COOKIES);
-export const Next = paramDecoratorFactory(PARAMETER_TYPE.NEXT);
+export const request = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);
+export const response = paramDecoratorFactory(PARAMETER_TYPE.RESPONSE);
+export const requestParam = paramDecoratorFactory(PARAMETER_TYPE.PARAMS);
+export const queryParam = paramDecoratorFactory(PARAMETER_TYPE.QUERY);
+export const requestBody = paramDecoratorFactory(PARAMETER_TYPE.BODY);
+export const requestHeaders = paramDecoratorFactory(PARAMETER_TYPE.HEADERS);
+export const cookies = paramDecoratorFactory(PARAMETER_TYPE.COOKIES);
+export const next = paramDecoratorFactory(PARAMETER_TYPE.NEXT);
 
 function paramDecoratorFactory(parameterType: PARAMETER_TYPE): (name?: string) => ParameterDecorator {
     return function (name?: string): ParameterDecorator {
         name = name || "default";
-        return Params(parameterType, name);
+        return params(parameterType, name);
     };
 }
 
-export function Params(type: PARAMETER_TYPE, parameterName: string) {
+export function params(type: PARAMETER_TYPE, parameterName: string) {
     return function (target: Object, methodName: string, index: number) {
 
         let metadataList: interfaces.ControllerParameterMetadata = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,29 @@
 import { InversifyExpressServer } from "./server";
-import { Controller, Method, Get, Put, Post, Patch, Head, All, Delete,
-        Request, Response, RequestParam, QueryParam, RequestBody, RequestHeaders,
-        Cookies, Next } from "./decorators";
+import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
+        httpHead, all, httpDelete, request, response, requestParam, queryParam,
+        requestBody, requestHeaders, cookies, next } from "./decorators";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 
 export {
     interfaces,
     InversifyExpressServer,
-    Controller,
-    Method,
-    Get,
-    Put,
-    Post,
-    Patch,
-    Head,
-    All,
-    Delete,
+    controller,
+    httpMethod,
+    httpGet,
+    httpPut,
+    httpPost,
+    httpPatch,
+    httpHead,
+    all,
+    httpDelete,
     TYPE,
-    Request,
-    Response,
-    RequestParam,
-    QueryParam,
-    RequestBody,
-    RequestHeaders,
-    Cookies,
-    Next
+    request,
+    response,
+    requestParam,
+    queryParam,
+    requestBody,
+    requestHeaders,
+    cookies,
+    next
 };

--- a/test/bugs.test.ts
+++ b/test/bugs.test.ts
@@ -1,12 +1,13 @@
 import { expect } from "chai";
 import * as express from "express";
-import { Controller, Method, Get, Request, Response, RequestParam, QueryParam } from "../src/decorators";
+import { controller, httpMethod, httpGet, request, response, requestParam,
+         queryParam } from "../src/decorators";
 import { interfaces } from "../src/interfaces";
 import { METADATA_KEY, PARAMETER_TYPE } from "../src/constants";
 import { InversifyExpressServer } from "../src/server";
 import { Container, injectable } from "inversify";
 import { TYPE } from "../src/constants";
-import * as request from "supertest";
+import * as supertest from "supertest";
 
 describe("Unit Test: Previous bugs", () => {
 
@@ -15,12 +16,12 @@ describe("Unit Test: Previous bugs", () => {
         let container = new Container();
 
         @injectable()
-        @Controller("/api/test")
+        @controller("/api/test")
         class TestController {
-            @Get("/")
+            @httpGet("/")
             public get(
-                @Request() req: express.Request,
-                @Response() res: express.Response
+                @request() req: express.Request,
+                @response() res: express.Response
             ) {
                 expect(req.url).not.to.eql(undefined);
                 expect((req as any).setHeader).to.eql(undefined);
@@ -28,11 +29,11 @@ describe("Unit Test: Previous bugs", () => {
                 expect((res as any).url).to.eql(undefined);
                 res.json([{ id: 1 }, { id: 2 }]);
             }
-            @Get("/:id")
+            @httpGet("/:id")
             public getById(
-                @RequestParam("id") id: string,
-                @Request() req: express.Request,
-                @Response() res: express.Response
+                @requestParam("id") id: string,
+                @request() req: express.Request,
+                @response() res: express.Response
             ) {
                 expect(id).to.eql("5");
                 expect(req.url).not.to.eql(undefined);
@@ -47,37 +48,37 @@ describe("Unit Test: Previous bugs", () => {
         let server = new InversifyExpressServer(container);
         let app = server.build();
 
-        request(app).get("/api/test/")
-                    .expect("Content-Type", /json/)
-                    .expect(200)
-                    .then(response1 => {
-                        expect(Array.isArray(response1.body)).to.eql(true);
-                        expect(response1.body[0].id).to.eql("1");
-                        expect(response1.body[0].id).to.eql("2");
-                    });
+        supertest(app).get("/api/test/")
+                      .expect("Content-Type", /json/)
+                      .expect(200)
+                      .then(response1 => {
+                          expect(Array.isArray(response1.body)).to.eql(true);
+                          expect(response1.body[0].id).to.eql("1");
+                          expect(response1.body[0].id).to.eql("2");
+                      });
 
-        request(app).get("/api/test/5")
-                    .expect("Content-Type", /json/)
-                    .expect(200)
-                    .then(response2 => {
-                        expect(Array.isArray(response2.body)).to.eql(false);
-                        expect(response2.body.id).to.eql("5");
-                        done();
-                    });
+        supertest(app).get("/api/test/5")
+                      .expect("Content-Type", /json/)
+                      .expect(200)
+                      .then(response2 => {
+                          expect(Array.isArray(response2.body)).to.eql(false);
+                          expect(response2.body.id).to.eql("5");
+                          done();
+                      });
 
     });
          it("should support empty query params", (done) => {
         let container = new Container();
 
         @injectable()
-        @Controller("/api/test")
+        @controller("/api/test")
         class TestController {
-            @Get("/")
+            @httpGet("/")
             public get(
-                @Request() req: express.Request,
-                @Response() res: express.Response,
-                @QueryParam("empty") empty: string,
-                @QueryParam("test") test: string
+                @request() req: express.Request,
+                @response() res: express.Response,
+                @queryParam("empty") empty: string,
+                @queryParam("test") test: string
             ) {
                 return {empty: empty, test: test};
             }
@@ -88,14 +89,14 @@ describe("Unit Test: Previous bugs", () => {
         let server = new InversifyExpressServer(container);
         let app = server.build();
 
-        request(app).get("/api/test?test=testquery")
-                    .expect("Content-Type", /json/)
-                    .expect(200)
-                    .then(response1 => {
-                        expect(response1.body.test).to.eql("testquery");
-                        expect(response1.body.empty).to.be.undefined;
-                        done();
-                    });
+        supertest(app).get("/api/test?test=testquery")
+                      .expect("Content-Type", /json/)
+                      .expect(200)
+                      .then(response1 => {
+                          expect(response1.body.test).to.eql("testquery");
+                          expect(response1.body.empty).to.be.undefined;
+                          done();
+                      });
 
     });
 

--- a/test/decorators.test.ts
+++ b/test/decorators.test.ts
@@ -1,15 +1,15 @@
 import { expect } from "chai";
-import { Controller, Method, Params } from "../src/decorators";
+import { controller, httpMethod, params } from "../src/decorators";
 import { interfaces } from "../src/interfaces";
 import { METADATA_KEY, PARAMETER_TYPE } from "../src/constants";
 
 describe("Unit Test: Controller Decorators", () => {
 
-    it("should add controller metadata to a class when decorated with @Controller", (done) => {
+    it("should add controller metadata to a class when decorated with @controller", (done) => {
         let middleware = [function() { return; }, "foo", Symbol("bar")];
         let path = "foo";
 
-        @Controller(path, ...middleware)
+        @controller(path, ...middleware)
         class TestController {}
 
         let controllerMetadata: interfaces.ControllerMetadata = Reflect.getMetadata("_controller", TestController);
@@ -21,19 +21,19 @@ describe("Unit Test: Controller Decorators", () => {
     });
 
 
-    it("should add method metadata to a class when decorated with @Method", (done) => {
+    it("should add method metadata to a class when decorated with @httpMethod", (done) => {
         let middleware = [function() { return; }, "bar", Symbol("baz")];
         let path = "foo";
         let method = "get";
 
         class TestController {
-            @Method(method, path, ...middleware)
+            @httpMethod(method, path, ...middleware)
             public test() { return; }
 
-            @Method("foo", "bar")
+            @httpMethod("foo", "bar")
             public test2() { return; }
 
-            @Method("bar", "foo")
+            @httpMethod("bar", "foo")
             public test3() { return; }
         }
 
@@ -51,20 +51,20 @@ describe("Unit Test: Controller Decorators", () => {
         done();
     });
 
-    it("should add parameter metadata to a class when decorated with @Params", (done) => {
+    it("should add parameter metadata to a class when decorated with @params", (done) => {
         let middleware = [function() { return; }, "bar", Symbol("baz")];
         let path = "foo";
         let method = "get";
         let methodName = "test";
 
         class TestController {
-            @Method(method, path, ...middleware)
-            public test(@Params(PARAMETER_TYPE.PARAMS, "id") id: any, @Params(PARAMETER_TYPE.PARAMS, "cat") cat: any) { return; }
+            @httpMethod(method, path, ...middleware)
+            public test(@params(PARAMETER_TYPE.PARAMS, "id") id: any, @params(PARAMETER_TYPE.PARAMS, "cat") cat: any) { return; }
 
-            @Method("foo", "bar")
-            public test2(@Params(PARAMETER_TYPE.PARAMS, "dog")dog: any) { return; }
+            @httpMethod("foo", "bar")
+            public test2(@params(PARAMETER_TYPE.PARAMS, "dog")dog: any) { return; }
 
-            @Method("bar", "foo")
+            @httpMethod("bar", "foo")
             public test3() { return; }
         }
         let methodMetadataList: interfaces.ControllerParameterMetadata =

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import * as sinon from "sinon";
-import * as request from "supertest";
+import * as supertest from "supertest";
 import { expect } from "chai";
 import * as inversify from "inversify";
 import * as express from "express";
@@ -9,8 +9,10 @@ import * as cookieParser from "cookie-parser";
 import { injectable, Container } from "inversify";
 import { interfaces } from "../src/interfaces";
 import { InversifyExpressServer } from "../src/server";
-import { Controller, Method, All, Get, Post, Put, Patch, Head, Delete, Request, Response, Params,
-        RequestParam, RequestBody, QueryParam, RequestHeaders, Cookies, Next } from "../src/decorators";
+import { controller, httpMethod, all, httpGet, httpPost, httpPut, httpPatch,
+        httpHead, httpDelete, request, response, params, requestParam,
+        requestBody, queryParam, requestHeaders, cookies,
+        next } from "../src/decorators";
 import { TYPE, PARAMETER_TYPE } from "../src/constants";
 
 describe("Integration Tests:", () => {
@@ -27,9 +29,9 @@ describe("Integration Tests:", () => {
 
         it("should work for async controller methods", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) {
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) {
                     return new Promise(((resolve) => {
                         setTimeout(resolve, 100, "GET");
                     }));
@@ -38,16 +40,16 @@ describe("Integration Tests:", () => {
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", done);
         });
 
         it("should work for async controller methods that fails", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) {
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) {
                     return new Promise(((resolve, reject) => {
                         setTimeout(reject, 100, "GET");
                     }));
@@ -56,7 +58,7 @@ describe("Integration Tests:", () => {
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(500, done);
         });
@@ -64,20 +66,20 @@ describe("Integration Tests:", () => {
 
         it ("should work for methods which call next()", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
+                @httpGet("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
                     next();
                 }
 
-                @Get("/") public getTest2(req: express.Request, res: express.Response) {
+                @httpGet("/") public getTest2(req: express.Request, res: express.Response) {
                     return "GET";
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", done);
         });
@@ -85,9 +87,9 @@ describe("Integration Tests:", () => {
 
         it ("should work for async methods which call next()", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
+                @httpGet("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
                     return new Promise(((resolve) => {
                         setTimeout(() => {
                             next();
@@ -96,14 +98,14 @@ describe("Integration Tests:", () => {
                     }));
                 }
 
-                @Get("/") public getTest2(req: express.Request, res: express.Response) {
+                @httpGet("/") public getTest2(req: express.Request, res: express.Response) {
                     return "GET";
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", done);
         });
@@ -111,13 +113,13 @@ describe("Integration Tests:", () => {
 
         it ("should work for async methods called by next()", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
+                @httpGet("/") public getTest(req: express.Request, res: express.Response, next: express.NextFunction) {
                     next();
                 }
 
-                @Get("/") public getTest2(req: express.Request, res: express.Response) {
+                @httpGet("/") public getTest2(req: express.Request, res: express.Response) {
                     return new Promise(((resolve) => {
                         setTimeout(resolve, 100, "GET");
                     }));
@@ -126,7 +128,7 @@ describe("Integration Tests:", () => {
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", done);
         });
@@ -134,19 +136,19 @@ describe("Integration Tests:", () => {
 
         it("should work for each shortcut decorator", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
-                @Post("/") public postTest(req: express.Request, res: express.Response) { res.send("POST"); }
-                @Put("/") public putTest(req: express.Request, res: express.Response) { res.send("PUT"); }
-                @Patch("/") public patchTest(req: express.Request, res: express.Response) { res.send("PATCH"); }
-                @Head("/") public headTest(req: express.Request, res: express.Response) { res.send("HEAD"); }
-                @Delete("/") public deleteTest(req: express.Request, res: express.Response) { res.send("DELETE"); }
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpPost("/") public postTest(req: express.Request, res: express.Response) { res.send("POST"); }
+                @httpPut("/") public putTest(req: express.Request, res: express.Response) { res.send("PUT"); }
+                @httpPatch("/") public patchTest(req: express.Request, res: express.Response) { res.send("PATCH"); }
+                @httpHead("/") public headTest(req: express.Request, res: express.Response) { res.send("HEAD"); }
+                @httpDelete("/") public deleteTest(req: express.Request, res: express.Response) { res.send("DELETE"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             let deleteFn = () => { agent.delete("/").expect(200, "DELETE", done); };
             let head = () => { agent.head("/").expect(200, "HEAD", deleteFn); };
@@ -159,16 +161,16 @@ describe("Integration Tests:", () => {
         });
 
 
-        it("should work for more obscure HTTP methods using the Method decorator", (done) => {
+        it("should work for more obscure HTTP methods using the httpMethod decorator", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Method("propfind", "/") public getTest(req: express.Request, res: express.Response) { res.send("PROPFIND"); }
+                @httpMethod("propfind", "/") public getTest(req: express.Request, res: express.Response) { res.send("PROPFIND"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .propfind("/")
                 .expect(200, "PROPFIND", done);
         });
@@ -178,23 +180,23 @@ describe("Integration Tests:", () => {
             let result = {"hello": "world"};
 
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) { return result; }
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) { return result; }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, JSON.stringify(result), done);
         });
 
         it("should use custom router passed from configuration", () => {
             @injectable()
-            @Controller("/CaseSensitive")
+            @controller("/CaseSensitive")
             class TestController {
-                @Get("/Endpoint") public get() {
+                @httpGet("/Endpoint") public get() {
                     return "Such Text";
                 }
             }
@@ -207,15 +209,15 @@ describe("Integration Tests:", () => {
             server = new InversifyExpressServer(container, customRouter);
             const app = server.build();
 
-            const expectedSuccess = request(app)
+            const expectedSuccess = supertest(app)
                 .get("/CaseSensitive/Endpoint")
                 .expect(200, "Such Text");
 
-            const expectedNotFound1 = request(app)
+            const expectedNotFound1 = supertest(app)
                 .get("/casesensitive/endpoint")
                 .expect(404);
 
-            const expectedNotFound2 = request(app)
+            const expectedNotFound2 = supertest(app)
                 .get("/CaseSensitive/endpoint")
                 .expect(404);
 
@@ -229,9 +231,9 @@ describe("Integration Tests:", () => {
 
         it("should use custom routing configuration", () => {
             @injectable()
-            @Controller("/ping")
+            @controller("/ping")
             class TestController {
-                @Get("/endpoint") public get() {
+                @httpGet("/endpoint") public get() {
                     return "pong";
                 }
             }
@@ -239,7 +241,7 @@ describe("Integration Tests:", () => {
 
             server = new InversifyExpressServer(container, null, { rootPath: "/api/v1" });
 
-            return request(server.build())
+            return supertest(server.build())
                 .get("/api/v1/ping/endpoint")
                 .expect(200, "pong");
         });
@@ -276,14 +278,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (GET)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/", spyA, spyB, spyC) public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpGet("/", spyA, spyB, spyC) public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.get("/")
                 .expect(200, "GET", function () {
@@ -297,14 +299,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (POST)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Post("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("POST"); }
+                @httpPost("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("POST"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.post("/")
                 .expect(200, "POST", function () {
@@ -318,14 +320,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (PUT)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Put("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("PUT"); }
+                @httpPut("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("PUT"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.put("/")
                 .expect(200, "PUT", function () {
@@ -339,14 +341,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (PATCH)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Patch("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("PATCH"); }
+                @httpPatch("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("PATCH"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.patch("/")
                 .expect(200, "PATCH", function () {
@@ -360,14 +362,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (HEAD)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Head("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("HEAD"); }
+                @httpHead("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("HEAD"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.head("/")
                 .expect(200, "HEAD", function () {
@@ -381,14 +383,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (DELETE)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Delete("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("DELETE"); }
+                @httpDelete("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("DELETE"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.delete("/")
                 .expect(200, "DELETE", function () {
@@ -402,14 +404,14 @@ describe("Integration Tests:", () => {
 
         it("should call method-level middleware correctly (ALL)", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @All("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("ALL"); }
+                @all("/", spyA, spyB, spyC) public postTest(req: express.Request, res: express.Response) { res.send("ALL"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             agent.get("/")
                 .expect(200, "ALL", function () {
@@ -424,14 +426,14 @@ describe("Integration Tests:", () => {
 
         it("should call controller-level middleware correctly", (done) => {
             @injectable()
-            @Controller("/", spyA, spyB, spyC)
+            @controller("/", spyA, spyB, spyC)
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", function () {
                     expect(spyA.calledOnce).to.be.true;
@@ -445,9 +447,9 @@ describe("Integration Tests:", () => {
 
         it("should call server-level middleware correctly", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
@@ -459,7 +461,7 @@ describe("Integration Tests:", () => {
                app.use(spyC);
             });
 
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", function () {
                     expect(spyA.calledOnce).to.be.true;
@@ -473,9 +475,9 @@ describe("Integration Tests:", () => {
 
         it("should call all middleware in correct order", (done) => {
             @injectable()
-            @Controller("/", spyB)
+            @controller("/", spyB)
             class TestController {
-                @Get("/", spyC) public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpGet("/", spyC) public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
@@ -485,7 +487,7 @@ describe("Integration Tests:", () => {
                app.use(spyA);
             });
 
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "GET", function () {
                     expect(spyA.calledOnce).to.be.true;
@@ -501,9 +503,9 @@ describe("Integration Tests:", () => {
             const strId = "spyB";
 
             @injectable()
-            @Controller("/", symbolId, strId)
+            @controller("/", symbolId, strId)
             class TestController {
-                @Get("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
+                @httpGet("/") public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
 
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
@@ -512,7 +514,7 @@ describe("Integration Tests:", () => {
 
             server = new InversifyExpressServer(container);
 
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             return agent.get("/")
                 .expect(200, "GET")
@@ -528,9 +530,9 @@ describe("Integration Tests:", () => {
             const strId = "spyB";
 
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/", symbolId, strId)
+                @httpGet("/", symbolId, strId)
                 public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
 
@@ -540,7 +542,7 @@ describe("Integration Tests:", () => {
 
             server = new InversifyExpressServer(container);
 
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             return agent.get("/")
                 .expect(200, "GET")
@@ -556,9 +558,9 @@ describe("Integration Tests:", () => {
             const strId = "spyB";
 
             @injectable()
-            @Controller("/", symbolId)
+            @controller("/", symbolId)
             class TestController {
-                @Get("/", strId)
+                @httpGet("/", strId)
                 public getTest(req: express.Request, res: express.Response) { res.send("GET"); }
             }
 
@@ -568,7 +570,7 @@ describe("Integration Tests:", () => {
 
             server = new InversifyExpressServer(container);
 
-            let agent = request(server.build());
+            let agent = supertest(server.build());
 
             return agent.get("/")
                 .expect(200, "GET")
@@ -582,65 +584,65 @@ describe("Integration Tests:", () => {
     describe("Parameters:", () => {
         it("should bind a method parameter to the url parameter of the web request", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
                 // tslint:disable-next-line:max-line-length
-                @Get(":id") public getTest( @RequestParam("id") id: string, req: express.Request, res: express.Response) {
+                @httpGet(":id") public getTest(@requestParam("id") id: string, req: express.Request, res: express.Response) {
                     return id;
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/foo")
                 .expect(200, "foo", done);
         });
 
         it("should bind a method parameter to the request object", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get(":id") public getTest(@Request() req: express.Request) {
+                @httpGet(":id") public getTest(@request() req: express.Request) {
                     return req.params.id;
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/GET")
                 .expect(200, "GET", done);
         });
 
         it("should bind a method parameter to the response object", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(@Response() res: express.Response) {
+                @httpGet("/") public getTest(@response() res: express.Response) {
                     return res.send("foo");
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "foo", done);
         });
 
         it("should bind a method parameter to a query parameter", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(@QueryParam("id") id: string) {
+                @httpGet("/") public getTest(@queryParam("id") id: string) {
                     return id;
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .query("id=foo")
                 .expect(200, "foo", done);
@@ -648,9 +650,9 @@ describe("Integration Tests:", () => {
 
         it("should bind a method parameter to the request body", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Post("/") public getTest(@RequestBody() body: string) {
+                @httpPost("/") public getTest(@requestBody() body: string) {
                     return body;
                 }
             }
@@ -661,7 +663,7 @@ describe("Integration Tests:", () => {
             server.setConfig((app) => {
                 app.use(bodyParser.json());
             });
-            request(server.build())
+            supertest(server.build())
                 .post("/")
                 .send(body)
                 .expect(200, body, done);
@@ -669,16 +671,16 @@ describe("Integration Tests:", () => {
 
         it("should bind a method parameter to the request headers", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(@RequestHeaders("testhead") headers: any) {
+                @httpGet("/") public getTest(@requestHeaders("testhead") headers: any) {
                     return headers;
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .set("TestHead", "foo")
                 .expect(200, "foo", done);
@@ -686,9 +688,9 @@ describe("Integration Tests:", () => {
 
         it("should bind a method parameter to a cookie", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getCookie(@Cookies("cookie") cookie: any, req: express.Request, res: express.Response) {
+                @httpGet("/") public getCookie(@cookies("cookie") cookie: any, req: express.Request, res: express.Response) {
                     if (cookie) {
                         res.send(cookie);
                     } else {
@@ -706,27 +708,27 @@ describe("Integration Tests:", () => {
                     next();
                 });
             });
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect("set-cookie", "cookie=hey; Path=/", done);
         });
 
         it("should bind a method parameter to the next function", (done) => {
             @injectable()
-            @Controller("/")
+            @controller("/")
             class TestController {
-                @Get("/") public getTest(@Next() next: any) {
+                @httpGet("/") public getTest(@next() next: any) {
                     let err = new Error("foo");
                     return next();
                 }
-                @Get("/") public getResult() {
+                @httpGet("/") public getResult() {
                     return "foo";
                 }
             }
             container.bind<interfaces.Controller>(TYPE.Controller).to(TestController).whenTargetNamed("TestController");
 
             server = new InversifyExpressServer(container);
-            request(server.build())
+            supertest(server.build())
                 .get("/")
                 .expect(200, "foo", done);
         });


### PR DESCRIPTION
Renamed all decorators to lowercase according to [issue #596](https://github.com/inversify/InversifyJS/issues/596)

## Description
All decorators have been just renamed to lowercase, with the expection of HTTP method decorators - these have been prefixed with `http` because `delete` is a reserved word and it cannot be used as an identifier. So new names are `httpGet`, `httpPost`, ..., etc.
Also, decorators in unit tests have been renamed and import name of supertest library has been changed from `request` to `supertest` to avoid name collision with `@request` decorator.
Documentation (README.md) has been updated to match new decorator names.

## Related Issue
https://github.com/inversify/InversifyJS/issues/596

## How Has This Been Tested?
All unit tests pass successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes (because no code has been added).
- [x] All new and existing tests passed.
