### PR TITLE
Non-native promise handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/inversify/inversify-express-utils#readme",
   "devDependencies": {
+    "@types/bluebird": "^3.5.8",
     "@types/body-parser": "^1.16.3",
     "@types/chai": "^4.0.1",
     "@types/cookie-parser": "^1.3.30",
@@ -32,6 +33,7 @@
     "@types/mocha": "^2.2.33",
     "@types/sinon": "^2.1.0",
     "@types/supertest": "^2.0.0",
+    "bluebird": "^3.5.0",
     "body-parser": "^1.17.1",
     "chai": "^4.0.0",
     "cookie-parser": "^1.4.3",

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,20 +139,14 @@ export class InversifyExpressServer  {
             let args = this.extractParameters(req, res, next, parameterMetadata);
             let result: any = this._container.getNamed(TYPE.Controller, controllerName)[key](...args);
             // try to resolve promise
-            if (result && result instanceof Promise) {
-
-                result.then((value: any) => {
+            Promise.resolve(result)
+                .then((value: any) => {
                     if (value && !res.headersSent) {
                         res.send(value);
                     }
                 })
-                .catch((error: any) => {
-                   next(error);
-                });
-
-            } else if (result && !res.headersSent) {
-                res.send(result);
-            }
+                .catch((err: any) => {
+                    next(err);   });
         };
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -138,15 +138,14 @@ export class InversifyExpressServer  {
         return (req: express.Request, res: express.Response, next: express.NextFunction) => {
             let args = this.extractParameters(req, res, next, parameterMetadata);
             let result: any = this._container.getNamed(TYPE.Controller, controllerName)[key](...args);
-            // try to resolve promise
             Promise.resolve(result)
                 .then((value: any) => {
                     if (value && !res.headersSent) {
                         res.send(value);
                     }
                 })
-                .catch((err: any) => {
-                    next(err);   });
+                .catch((error: any) => {
+                    next(error);   });
         };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The changes made enable non-native promise handling functionality for inversify-express-utils, such that both native es6 promises as well as promise libraries such as Bluebird are supported.

## Related Issue
https://github.com/inversify/InversifyJS/issues/624

## Motivation and Context
Inversify-express-utils should give programmers the flexibility to use a promise library of their choice.

## How Has This Been Tested?
All unit tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
