### PR TITLE
Controllers should not be forced to send a response for falsey return values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ test/**/*.js.map
 type_definitions/**/*.js
 type_definitions/*.js
 package-lock.json
+
+# JetBrains IDE
+.idea

--- a/src/server.ts
+++ b/src/server.ts
@@ -224,7 +224,12 @@ export class InversifyExpressServer  {
                 let result = childContainer.getNamed<any>(TYPE.Controller, controllerName)[key](...args);
                 Promise.resolve(result)
                     .then((value: any) => {
-                        if (value && !res.headersSent) {
+                        if (value instanceof Function) {
+                            value();
+                        } else if (!res.headersSent) {
+                            if (value === undefined) {
+                                res.status(204);
+                            }
                             res.send(value);
                         }
                     })

--- a/test/framework.test.ts
+++ b/test/framework.test.ts
@@ -98,7 +98,7 @@ describe("Integration Tests:", () => {
                 .expect(500, done);
         });
 
-        it ("should work for methods which call nextFunc()", (done) => {
+        it("should work for methods which call nextFunc()", (done) => {
 
             @controller("/")
             class TestController {
@@ -118,7 +118,7 @@ describe("Integration Tests:", () => {
         });
 
 
-        it ("should work for async methods which call nextFunc()", (done) => {
+        it("should work for async methods which call nextFunc()", (done) => {
 
             @controller("/")
             class TestController {
@@ -143,12 +143,12 @@ describe("Integration Tests:", () => {
         });
 
 
-        it ("should work for async methods called by nextFunc()", (done) => {
+        it("should work for async methods called by nextFunc()", (done) => {
 
             @controller("/")
             class TestController {
                 @httpGet("/") public getTest(req: express.Request, res: express.Response, nextFunc: express.NextFunction) {
-                    nextFunc();
+                    return nextFunc;
                 }
 
                 @httpGet("/") public getTest2(req: express.Request, res: express.Response) {
@@ -268,6 +268,20 @@ describe("Integration Tests:", () => {
             return supertest(server.build())
                 .get("/api/v1/ping/endpoint")
                 .expect(200, "pong");
+        });
+
+        it("should work for controller methods who's return value is falsey", (done) => {
+            @controller("/user")
+            class TestController {
+                @httpDelete("/") private async delete(): Promise<void> {
+                    return;
+                }
+            }
+
+            server = new InversifyExpressServer(container);
+            supertest(server.build())
+                .delete("/user")
+                .expect(204, "", done);
         });
     });
 


### PR DESCRIPTION
## Description
Modified the handling of the the controller's return value so that a the status code 204 is set if the value is undefined after which it will send the result regardless of the type of value.

## Related Issue
https://github.com/inversify/InversifyJS/issues/764

## Motivation and Context
Controllers should not be forced to send a response if the value they are returning is undefined, NULL, false, or otherwise evaluates as false.  Without this change all responses would need to be wrapped to ensure that `response.send()` is called.

## How Has This Been Tested?
```typescript
it("should work for controller methods who's return value is falsey", (done) => {
    @controller("/user")
    class TestController {
        @httpDelete("/") private async delete(): Promise<void> {
            return;
        }
    }

    server = new InversifyExpressServer(container);
    supertest(server.build())
        .delete("/user")
        .expect(204, "", done);
});
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
