### PR TITLE
Middleware is capable of (re)binding Inversify services in the scope of an Express HTTP request

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/inversify/inversify-express-utils#readme",
   "devDependencies": {
+    "@types/async": "2.0.49",
     "@types/bluebird": "3.5.20",
     "@types/body-parser": "1.17.0",
     "@types/chai": "4.1.3",
@@ -34,6 +35,7 @@
     "@types/prettyjson": "0.0.28",
     "@types/sinon": "5.0.1",
     "@types/supertest": "2.0.4",
+    "async": "2.6.1",
     "bluebird": "3.5.1",
     "body-parser": "1.18.3",
     "chai": "4.1.2",

--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,5 +1,5 @@
 import * as express from "express";
-import { injectable } from "inversify";
+import { Container, injectable, interfaces as inversifyInterfaces } from "inversify";
 import { injectHttpContext } from "./decorators";
 import { interfaces } from "./interfaces";
 
@@ -8,6 +8,15 @@ export abstract class BaseMiddleware implements BaseMiddleware {
     // httpContext is initialized when the middleware is invoked
     // see resolveMidleware in server.ts for more details
     protected readonly httpContext: interfaces.HttpContext;
+
+    private readonly _container: Container;
+
+    protected bind<T>(serviceIdentifier: inversifyInterfaces.ServiceIdentifier<T>): inversifyInterfaces.BindingToSyntax<T> {
+        return this._container.isBound(serviceIdentifier)
+            ? this._container.rebind(serviceIdentifier)
+            : this._container.bind(serviceIdentifier);
+    }
+
     public abstract handler(
         req: express.Request,
         res: express.Response,

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,6 +192,7 @@ export class InversifyExpressServer {
                     ) {
                         const httpContext = _self._getHttpContext(req);
                         (m as any).httpContext = httpContext;
+                        (m as any)._container = _self._container;
                         m.handler(req, res, next);
                     };
                 } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hi guys and thanks for your amazing work on `Inversify` and `Inversify-Express-Utils`!

This PR adds a feature enabling middleware that extends `BaseMiddleware` to re-bind services in the IoC container. If those services are re-bound `.inRequestScope()`, they will live only in the context of serving one HTTP request.

Hope you find it useful!
Jan

## Description
<!--- Describe your changes in detail -->

## Related Issue

- inversify/inversifyjs#381

## Motivation and Context

I need to provide several of the dependencies of the services injected into the InversifyExpressServer with a value based on a property of the HTTP request. I could provide that value as a parameter of the method invocation, but since the dependency chain is fairly long and I need that value at the very last dependency and in several places, it seems to make sense to inject that value into the IoC container and then retrieve it where I need it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Automated tests as well as manual tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
