### PR TITLE
Created the @principal decorator.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,6 @@ happening again in the future
 
 - Please keep the test coverage at 100%. Write additional unit tests if necessary
 
--  Please create an issue before sending a PR if it is going to change the public interface of InversifyJS or includes significant architecture changes
+- Please create an issue before sending a PR if it is going to change the public interface of InversifyJS or includes significant architecture changes
 
 - Feel free to ask for help from other members of the InversifyJS team via the chat / mailing list or github issues

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Binds a method parameter to the request cookies.
 
 Binds a method parameter to the next() function.
 
+### `@principal()`
+
+Binds a method parameter to the user principal obtained from the AuthProvider.
+
 ## BaseHttpController
 
 The `BaseHttpController` is a base class that provides a significant amount of helper functions in order to aid writing testable controllers.  When returning a response from a method defined on one of these controllers, you may use the `response` object available on the `httpContext` property described in the next section, or you may return an `HttpResponseMessage`, or you may return an object that implements the IHttpActionResult interface.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inversify-express-utils",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Some utilities for the development of express applications with Inversify",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "express": "4.16.2",
-    "http-status-codes": "^1.3.0"
+    "http-status-codes": "^1.3.0",
+    "npm": "^6.1.0"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,8 @@ export enum PARAMETER_TYPE {
     BODY,
     HEADERS,
     COOKIES,
-    NEXT
+    NEXT,
+    PRINCIPAL
 }
 
 export const DUPLICATED_CONTROLLER_NAME = (name: string) =>

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,7 +1,6 @@
 import { interfaces as inversifyInterfaces } from "inversify";
-import { BaseHttpController } from "./base_http_controller";
 import { interfaces } from "./interfaces";
-import { PARAMETER_TYPE, TYPE } from "./constants";
+import { PARAMETER_TYPE } from "./constants";
 import {
     getControllersFromContainer,
     getControllerMetadata,
@@ -13,7 +12,7 @@ export function getRouteInfo(container: inversifyInterfaces.Container) {
 
     const raw = getRawMetadata(container);
 
-    const info = raw.map(r => {
+    return raw.map(r => {
 
         const controllerId = r.controllerMetadata.target.name;
 
@@ -25,7 +24,7 @@ export function getRouteInfo(container: inversifyInterfaces.Container) {
             const paramMetadata = r.parameterMetadata;
             let args: string[] | undefined = undefined;
 
-            if (paramMetadata !== undefined ) {
+            if (paramMetadata !== undefined) {
                 const paramMetadataForKey = paramMetadata[m.key] || undefined;
                 if (paramMetadataForKey) {
                     args = (r.parameterMetadata[m.key] || []).map(a => {
@@ -55,6 +54,9 @@ export function getRouteInfo(container: inversifyInterfaces.Container) {
                             case PARAMETER_TYPE.COOKIES:
                                 type = "@cookies";
                                 break;
+                            case PARAMETER_TYPE.PRINCIPAL:
+                                type = "@principal";
+                                break;
                         }
                         return `${type} ${a.parameterName}`;
                     });
@@ -80,15 +82,13 @@ export function getRouteInfo(container: inversifyInterfaces.Container) {
 
     });
 
-    return info;
-
 }
 
 export function getRawMetadata(container: inversifyInterfaces.Container) {
 
     const controllers = getControllersFromContainer(container, true);
 
-    const raw = controllers.map((controller) => {
+    return controllers.map((controller) => {
 
         let constructor = controller.constructor;
         let controllerMetadata: interfaces.ControllerMetadata = getControllerMetadata(constructor);
@@ -102,8 +102,6 @@ export function getRawMetadata(container: inversifyInterfaces.Container) {
         };
 
     });
-
-    return raw;
 
 }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -98,6 +98,7 @@ export const requestBody: () => ParameterDecorator = paramDecoratorFactory(PARAM
 export const requestHeaders: (headderName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.HEADERS);
 export const cookies: (cookieName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.COOKIES);
 export const next: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.NEXT);
+export const principal: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PRINCIPAL);
 
 function paramDecoratorFactory(parameterType: PARAMETER_TYPE): (name?: string) => ParameterDecorator {
     return function (name?: string): ParameterDecorator {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { InversifyExpressServer } from "./server";
 import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
         httpHead, all, httpDelete, request, response, requestParam, queryParam,
-        requestBody, requestHeaders, cookies, next, injectHttpContext } from "./decorators";
+        requestBody, requestHeaders, cookies, next, principal, injectHttpContext } from "./decorators";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 import * as results from "./results";
@@ -37,6 +37,7 @@ export {
     requestHeaders,
     cookies,
     next,
+    principal,
     BaseHttpController,
     injectHttpContext,
     BaseMiddleware,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added a new parameter decorator that assigns the user principal as the parameter value as provided by the AuthProvider.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is related to issue #205 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was made to allow simpler access to the user principal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests made involved a default scenario, where no AuthProvider is set, therefore returning a plain `{ details: null}` object. Also, there's another test which checks the principal details as provided by the preset AuthProvider.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
