### PR TITLE
Fix bug handling HttpResponseMessage that has no content

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -221,9 +221,10 @@ export class InversifyExpressServer {
 
     private async handleHttpResponseMessage(message: HttpResponseMessage, res: express.Response) {
         this.copyHeadersTo(message.headers, res);
-        this.copyHeadersTo(message.content.headers, res);
 
         if (message.content !== undefined) {
+            this.copyHeadersTo(message.content.headers, res);
+
             res.status(message.statusCode)
                // If the content is a number, ensure we change it to a string, else our content is treated
                // as a statusCode rather than as the content of the Response

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -6,6 +6,8 @@ import { controller } from "../src/decorators";
 import { Container, injectable } from "inversify";
 import { TYPE } from "../src/constants";
 import { cleanUpMetadata } from "../src/utils";
+import { HttpResponseMessage } from "../src";
+import { Mock, Times, MockBehavior } from "moq.ts";
 
 describe("Unit Test: InversifyExpressServer", () => {
 
@@ -96,5 +98,17 @@ describe("Unit Test: InversifyExpressServer", () => {
         let serverWithCustomApp = new InversifyExpressServer(container, null, null, app);
         expect((serverWithCustomApp as any)._app).to.eq(app);
         expect((serverWithDefaultApp as any)._app).to.not.eql((serverWithCustomApp as any)._app);
+    });
+
+    it("Should handle a HttpResponseMessage that has no content", () => {
+        let container = new Container();
+        let server = new InversifyExpressServer(container);
+
+        let httpResponseMessageWithoutContent = new HttpResponseMessage(404);
+        let mockResponse = new Mock<express.Response>().setBehaviorStrategy(MockBehavior.Loose);
+
+        (server as any).handleHttpResponseMessage(httpResponseMessageWithoutContent, mockResponse.object());
+
+        mockResponse.verify(instance => instance.sendStatus(404), Times.Once());
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes bug where an error is thrown when the server tries to handle a HttpResponseMessage that does not contain any message content, as is the case when using BaseHttpController helper functions.

## Description
<!--- Describe your changes in detail -->
Moved code handling content headers inside undefined conditional check.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inversify/InversifyJS/issues/912

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug where server would throw an error with a response that has no content.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested InversifyExpressServer#handleHttpResponseMessage to ensure the express.Response#sendStatus would be called with a HttpResponseMessage that has no content.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.