### PR TITLE
Add json response type

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ On the BaseHttpController, we provide a litany of helper methods to ease returni
 * ExceptionResult
 * InternalServerError
 * NotFoundResult
+* JsonResult
 
 ```ts
 import { injectable, inject } from "inversify";

--- a/README.md
+++ b/README.md
@@ -325,6 +325,55 @@ class ExampleController extends BaseHttpController {
     }
 ```
 
+### JsonResult
+
+In some scenarios, you'll want to set the status code of the response.
+This can be done by using the `json` helper method provided by `BaseHttpController`.
+
+```ts
+import {
+    controller, httpGet, BaseHttpController
+} from "inversify-express-utils";
+
+@controller("/")
+export class ExampleController extends BaseHttpController {
+    @httpGet("/")
+    public async get() {
+        const content = { foo: "bar" };
+        const statusCode = 403;
+
+        return this.json(content, statusCode);
+    }
+}
+```
+
+This gives you the flexability to create your own responses while keeping unit testing simple.
+
+```ts
+import { expect } from "chai";
+
+import { ExampleController } from "./example-controller";
+import { results } from "inversify-express-utils";
+
+describe("ExampleController", () => {
+    let controller: ExampleController;
+
+    beforeEach(() => {
+        controller = new ExampleController();
+    });
+
+    describe("#get", () => {
+        it("should have a status code of 403", async () => {
+            const response = await controller.get();
+
+            expect(response).to.be.an.instanceof(results.JsonResult);
+            expect(response.statusCode).to.equal(403);
+        });
+    });
+});
+```
+*This example uses [Mocha](https://mochajs.org) and [Chai](http://www.chaijs.com) as a unit testing framework*
+
 ## HttpContext
 
 The `HttpContext` property allow us to access the current request,
@@ -526,10 +575,10 @@ container.bind<interfaces.Controller>(TYPE.Controller)
 ### Request-scope services
 
 Middleware extending `BaseMiddleware` is capable of re-binding services in the scope of a HTTP request.
-This is useful if you need access to a HTTP request or context-specific property in a service that doesn't have 
+This is useful if you need access to a HTTP request or context-specific property in a service that doesn't have
 the direct access to them otherwise.
 
-Consider the below `TracingMiddleware`. In this example we want to capture the `X-Trace-Id` header from the incoming request 
+Consider the below `TracingMiddleware`. In this example we want to capture the `X-Trace-Id` header from the incoming request
 and make it available to our IoC services as `TYPES.TraceIdValue`:
 
 ```typescript
@@ -586,7 +635,7 @@ class Service {
 ```
 
 The `BaseMiddleware.bind()` method will bind the `TYPES.TraceIdValue` if it hasn't been bound yet or re-bind if it has
-already been bound. 
+already been bound.
 
 ## Route Map
 

--- a/src/base_http_controller.ts
+++ b/src/base_http_controller.ts
@@ -15,8 +15,10 @@ import {
     NotFoundResult,
     RedirectResult,
     ResponseMessageResult,
-    StatusCodeResult
+    StatusCodeResult,
+    JsonResult
 } from "./results";
+import { OK } from "http-status-codes";
 
 @injectable()
 export class BaseHttpController {
@@ -66,5 +68,9 @@ export class BaseHttpController {
 
     protected statusCode(statusCode: number) {
         return new StatusCodeResult(statusCode, this);
+    }
+
+    protected json(content: any, statusCode: number = OK) {
+        return new JsonResult(content, statusCode, this);
     }
 }

--- a/src/content/jsonContent.ts
+++ b/src/content/jsonContent.ts
@@ -1,0 +1,21 @@
+import { HttpContent } from "./httpContent";
+
+const DEFAULT_MEDIA_TYPE = "application/json";
+
+export class JsonContent extends HttpContent {
+  private content: string;
+
+  constructor(content: any);
+  constructor(content: any, mediaType: string);
+  constructor(content: any, private mediaType: string = DEFAULT_MEDIA_TYPE) {
+    super();
+
+    this.content = JSON.stringify(content);
+
+    this.headers["content-type"] = mediaType;
+  }
+
+  public readAsStringAsync() {
+    return Promise.resolve(this.content);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { cleanUpMetadata } from "./utils";
 import { getRouteInfo, getRawMetadata } from "./debug";
 import { HttpResponseMessage } from "./httpResponseMessage";
 import { StringContent } from "./content/stringContent";
+import { JsonContent } from "./content/jsonContent";
 import { HttpContent } from "./content/httpContent";
 
 export {
@@ -43,5 +44,6 @@ export {
     HttpResponseMessage,
     HttpContent,
     StringContent,
+    JsonContent,
     results
 };

--- a/src/results/JsonResult.ts
+++ b/src/results/JsonResult.ts
@@ -6,8 +6,8 @@ import { BaseHttpController } from "../base_http_controller";
 export default class JsonResult implements interfaces.IHttpActionResult {
 
   constructor(
-    private json: any,
-    private statusCode: number,
+    public readonly json: any,
+    public readonly statusCode: number,
     private apiController: BaseHttpController) {}
 
   public async executeAsync() {

--- a/src/results/JsonResult.ts
+++ b/src/results/JsonResult.ts
@@ -1,0 +1,19 @@
+import { interfaces } from "../interfaces";
+import { HttpResponseMessage } from "../httpResponseMessage";
+import { JsonContent } from "../content/jsonContent";
+import { BaseHttpController } from "../base_http_controller";
+
+export default class JsonResult implements interfaces.IHttpActionResult {
+
+  constructor(
+    private json: any,
+    private statusCode: number,
+    private apiController: BaseHttpController) {}
+
+  public async executeAsync() {
+    const response = new HttpResponseMessage(this.statusCode);
+    response.content = new JsonContent(this.json);
+    return response;
+  }
+
+}

--- a/src/results/index.ts
+++ b/src/results/index.ts
@@ -10,3 +10,4 @@ export { default as RedirectResult } from "./RedirectResult";
 export { default as ResponseMessageResult } from "./ResponseMessageResult";
 export { default as ConflictResult } from "./ConflictResult";
 export { default as StatusCodeResult } from "./StatusCodeResult";
+export { default as JsonResult } from "./JsonResult";

--- a/test/content/jsonContent.test.ts
+++ b/test/content/jsonContent.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { JsonContent } from "../../src/content/jsonContent";
+
+describe("JsonContent", () => {
+  it("should have application/json as the default media type", () => {
+    const content = new JsonContent({});
+    expect(content.headers["content-type"]).to.equal("application/json");
+  });
+
+  it("should respond with the stringified version of the object", (done) => {
+    const mockObject = {
+      type: "fake",
+      success: true,
+      count: 6
+    };
+
+    const content = new JsonContent(mockObject);
+
+    content.readAsStringAsync().then((value) => {
+      expect(value).to.equal(JSON.stringify(mockObject));
+      done();
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added a json response type.

To my knowledge, currently you can't change the status code when returning a json object. This will add a json helper method which will accept a status code and json content.

Created a JsonContent type that extends HttpContent. To make use of this, I added a helper method `BaseHttpController#json(content: any, statusCode: number = OK)`. This returns a JsonResult which accepts the Json content and a status code.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/inversify/InversifyJS/issues/913

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently you can't change the status code when returning a json object. This will add a json helper method which will accept a status code and json content.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.