### PR TITLE
Fix nameless param injector for params, query, cookies and header

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,10 @@
-const TYPE = {
+export const TYPE = {
     AuthProvider: Symbol.for("AuthProvider"),
     Controller: Symbol.for("Controller"),
     HttpContext: Symbol.for("HttpContext")
 };
 
-const METADATA_KEY = {
+export const METADATA_KEY = {
     controller: "inversify-express-utils:controller",
     controllerMethod: "inversify-express-utils:controller-method",
     controllerParameter: "inversify-express-utils:controller-parameter",
@@ -29,6 +29,4 @@ export const DUPLICATED_CONTROLLER_NAME = (name: string) =>
 export const NO_CONTROLLERS_FOUND = "No controllers have been found! " +
     "Please ensure that you have register at least one Controller.";
 
-const DEFAULT_ROUTING_ROOT_PATH = "/";
-
-export { TYPE, METADATA_KEY, DEFAULT_ROUTING_ROOT_PATH };
+export const DEFAULT_ROUTING_ROOT_PATH = "/";

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -92,28 +92,28 @@ export function httpMethod(method: string, path: string, ...middleware: interfac
 
 export const request: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.REQUEST);
 export const response: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.RESPONSE);
-export const requestParam: (paramName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PARAMS);
-export const queryParam: (queryParamName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.QUERY);
+export const requestParam: (paramName?: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PARAMS);
+export const queryParam: (queryParamName?: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.QUERY);
 export const requestBody: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.BODY);
-export const requestHeaders: (headderName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.HEADERS);
-export const cookies: (cookieName: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.COOKIES);
+export const requestHeaders: (headerName?: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.HEADERS);
+export const cookies: (cookieName?: string) => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.COOKIES);
 export const next: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.NEXT);
 export const principal: () => ParameterDecorator = paramDecoratorFactory(PARAMETER_TYPE.PRINCIPAL);
 
 function paramDecoratorFactory(parameterType: PARAMETER_TYPE): (name?: string) => ParameterDecorator {
     return function (name?: string): ParameterDecorator {
-        name = name || "default";
         return params(parameterType, name);
     };
 }
 
-export function params(type: PARAMETER_TYPE, parameterName: string) {
+export function params(type: PARAMETER_TYPE, parameterName?: string) {
     return function (target: Object, methodName: string, index: number) {
 
         let metadataList: interfaces.ControllerParameterMetadata = {};
         let parameterMetadataList: interfaces.ParameterMetadata[] = [];
         let parameterMetadata: interfaces.ParameterMetadata = {
             index: index,
+            injectRoot: parameterName === undefined,
             parameterName: parameterName,
             type: type
         };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,12 +23,13 @@ namespace interfaces {
     }
 
     export interface ParameterMetadata {
-        parameterName: string;
+        parameterName?: string;
+        injectRoot: boolean;
         index: number;
         type: PARAMETER_TYPE;
     }
 
-    export interface Controller {}
+    export interface Controller { }
 
     export interface HandlerDecorator {
         (target: any, key: string, value: any): void;

--- a/src/server.ts
+++ b/src/server.ts
@@ -318,7 +318,7 @@ export class InversifyExpressServer {
             return [req, res, next];
         }
 
-        params.forEach(({type, index, parameterName}) => {
+        params.forEach(({ type, index, parameterName, injectRoot }) => {
             switch (type) {
                 case PARAMETER_TYPE.REQUEST:
                     args[index] = req;
@@ -327,19 +327,19 @@ export class InversifyExpressServer {
                     args[index] = next;
                     break;
                 case PARAMETER_TYPE.PARAMS:
-                    args[index] = this.getParam(req, "params", parameterName);
+                    args[index] = this.getParam(req, "params", injectRoot, parameterName);
                     break;
                 case PARAMETER_TYPE.QUERY:
-                    args[index] = this.getParam(req, "query", parameterName);
+                    args[index] = this.getParam(req, "query", injectRoot, parameterName);
                     break;
                 case PARAMETER_TYPE.BODY:
                     args[index] = req.body;
                     break;
                 case PARAMETER_TYPE.HEADERS:
-                    args[index] = this.getParam(req, "headers", parameterName.toLowerCase());
+                    args[index] = this.getParam(req, "headers", injectRoot, parameterName);
                     break;
                 case PARAMETER_TYPE.COOKIES:
-                    args[index] = this.getParam(req, "cookies", parameterName);
+                    args[index] = this.getParam(req, "cookies", injectRoot, parameterName);
                     break;
                 case PARAMETER_TYPE.PRINCIPAL:
                     args[index] = this._getPrincipal(req);
@@ -354,9 +354,15 @@ export class InversifyExpressServer {
         return args;
     }
 
-    private getParam(source: express.Request, paramType: string, name: string) {
+    private getParam(source: express.Request, paramType: string, injectRoot: boolean, name?: string, ) {
+        if (paramType === "headers" && name) { name = name.toLowerCase(); }
         let param = source[paramType];
-        return param ? param[name] : undefined;
+
+        if (injectRoot) {
+            return param;
+        } else {
+            return (param && name) ? param[name] : undefined;
+        }
     }
 
     private _getPrincipal(req: express.Request): interfaces.Principal | null {


### PR DESCRIPTION
In the documentation it's stated that if the name is omitted for either `requestParam`, `requestQuery`, `cookies` or `requestHeader`, the full object will injected instead of the specific key. I think this was half implemented because there was a _magic string_ `"default"` set as `parameterName` if it was omitted, but then it wasn't marked as optional in the actual injectors and there was no code to actually deal with that and return the full object.

## Description
- I refactored the `ParameterMetadata` to contain na explicit `injectRoot` boolean property that gets set if the `attributeName` is omitted.
- I set the `attributeName` to be optional on the four injectors mentioned.
- I modified the param lookup function to return the whole object if `injectRoot` is true.

## Related Issue
https://github.com/inversify/InversifyJS/issues/937

## Motivation and Context
Fully stated in the context of the issue.

## How Has This Been Tested?
Wrote e2e tests that spin up server and reproduce the problem for all the injectors discussed. It validated that omitting the `attributeName` now results in the full object being inserted.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

> No changes to the documentation needed, as far as I can tell, this PR actually makes the current documentation accurate.