### PR TITLE
[inversify-express-utils] BaseMiddleware bindings unique to HTTP request

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mocha": "5.2.0",
     "moq.ts": "^2.6.0",
     "prettyjson": "1.2.1",
-    "publish-please": "3.2.0",
+    "publish-please": "4.0.0",
     "reflect-metadata": "0.1.12",
     "run-sequence": "2.2.1",
     "sinon": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/express": "4.16.0",
     "@types/mocha": "5.2.3",
     "@types/prettyjson": "0.0.28",
-    "@types/sinon": "5.0.2",
+    "@types/sinon": "5.0.3",
     "@types/supertest": "2.0.6",
     "async": "2.6.1",
     "bluebird": "3.5.1",

--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,6 +1,5 @@
 import * as express from "express";
-import { Container, injectable, interfaces as inversifyInterfaces } from "inversify";
-import { injectHttpContext } from "./decorators";
+import { injectable, interfaces as inversifyInterfaces } from "inversify";
 import { interfaces } from "./interfaces";
 
 @injectable()
@@ -9,12 +8,8 @@ export abstract class BaseMiddleware implements BaseMiddleware {
     // see resolveMidleware in server.ts for more details
     protected readonly httpContext: interfaces.HttpContext;
 
-    private readonly _container: Container;
-
     protected bind<T>(serviceIdentifier: inversifyInterfaces.ServiceIdentifier<T>): inversifyInterfaces.BindingToSyntax<T> {
-        return this._container.isBound(serviceIdentifier)
-            ? this._container.rebind(serviceIdentifier)
-            : this._container.bind(serviceIdentifier);
+        return this.httpContext.container.bind(serviceIdentifier);
     }
 
     public abstract handler(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,6 +63,7 @@ namespace interfaces {
     export interface HttpContext {
         request: express.Request;
         response: express.Response;
+        container: inversifyInterfaces.Container;
         user: Principal;
     }
 


### PR DESCRIPTION
## Description
Modified `BaseMiddleware.bind` to bind to the child container that is already used to bind the `HttpContext` and get the `Controller`. This ensures that services injected to the HTTP request scope are limited to that scope.

## Related Issue
https://github.com/inversify/InversifyJS/issues/962

## Motivation and Context
Services injected to the HTTP request scope using `BaseMiddleware.bind` were visible to both concurrent and future HTTP requests.

## How Has This Been Tested?
I have modified the existing test for HTTP request scoped services injected by `BaseMiddleware` to account for asynchronous middleware and added a new test as per the reproduction example in the associated issue. Both tests failed before my change and succeeded after it. I tested in the environment detailed in the associated issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
