### PR TITLE
[inversify-express-utils] BaseMiddleware bindings unique to HTTP request

### DIFF
--- a/src/base_middleware.ts
+++ b/src/base_middleware.ts
@@ -1,6 +1,5 @@
 import * as express from "express";
-import { Container, injectable, interfaces as inversifyInterfaces } from "inversify";
-import { injectHttpContext } from "./decorators";
+import { injectable, interfaces as inversifyInterfaces } from "inversify";
 import { interfaces } from "./interfaces";
 
 @injectable()
@@ -9,12 +8,8 @@ export abstract class BaseMiddleware implements BaseMiddleware {
     // see resolveMidleware in server.ts for more details
     protected readonly httpContext: interfaces.HttpContext;
 
-    private readonly _container: Container;
-
     protected bind<T>(serviceIdentifier: inversifyInterfaces.ServiceIdentifier<T>): inversifyInterfaces.BindingToSyntax<T> {
-        return this._container.isBound(serviceIdentifier)
-            ? this._container.rebind(serviceIdentifier)
-            : this._container.bind(serviceIdentifier);
+        return this.httpContext.container.bind(serviceIdentifier);
     }
 
     public abstract handler(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,6 +63,7 @@ namespace interfaces {
     export interface HttpContext {
         request: express.Request;
         response: express.Response;
+        container: inversifyInterfaces.Container;
         user: Principal;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -200,9 +200,9 @@ export class InversifyExpressServer {
                     res: express.Response,
                     next: express.NextFunction
                 ) {
-                    (m as any).httpContext = _self._getHttpContext(req);
-                    (m as any)._container = _self._container;
-                    m.handler(req, res, next);
+                    let mReq = _self._container.get<BaseMiddleware>(middlewareItem);
+                    (mReq as any).httpContext = _self._getHttpContext(req);
+                    mReq.handler(req, res, next);
                 };
             }
 
@@ -245,15 +245,12 @@ export class InversifyExpressServer {
             try {
                 let args = this.extractParameters(req, res, next, parameterMetadata);
 
-                // We use a childContainer for each request so we can be
-                // sure that the binding is unique for each HTTP request
-                let childContainer = this._container.createChild();
                 const httpContext = this._getHttpContext(req);
-                childContainer.bind<interfaces.HttpContext>(TYPE.HttpContext)
+                httpContext.container.bind<interfaces.HttpContext>(TYPE.HttpContext)
                     .toConstantValue(httpContext);
 
                 // invoke controller's action
-                const value = await childContainer.getNamed<any>(TYPE.Controller, controllerName)[key](...args);
+                const value = await httpContext.container.getNamed<any>(TYPE.Controller, controllerName)[key](...args);
 
                 if (value instanceof HttpResponseMessage) {
                     await this.handleHttpResponseMessage(value, res);
@@ -274,7 +271,7 @@ export class InversifyExpressServer {
         };
     }
 
-    private _getHttpContext(req: express.Request) {
+    private _getHttpContext(req: express.Request): interfaces.HttpContext {
         return Reflect.getMetadata(
             METADATA_KEY.httpContext,
             req
@@ -290,6 +287,9 @@ export class InversifyExpressServer {
         return {
             request: req,
             response: res,
+            // We use a childContainer for each request so we can be
+            // sure that the binding is unique for each HTTP request
+            container: this._container.createChild(),
             user: principal
         };
     }


### PR DESCRIPTION
## Description
Modified `BaseMiddleware.bind` to bind to the child container that is already used to bind the `HttpContext` and get the `Controller`. This ensures that services injected to the HTTP request scope are limited to that scope.

## Related Issue
https://github.com/inversify/InversifyJS/issues/962

## Motivation and Context
Services injected to the HTTP request scope using `BaseMiddleware.bind` were visible to both concurrent and future HTTP requests.

## How Has This Been Tested?
I have modified the existing test for HTTP request scoped services injected by `BaseMiddleware` to account for asynchronous middleware and added a new test as per the reproduction example in the associated issue. Both tests failed before my change and succeeded after it. I tested in the environment detailed in the associated issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
