### PR TITLE
It defines an IsAuthenticated decorator that is applied to routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,49 @@ class UserDetailsController extends BaseHttpController {
 }
 ```
 
+### Decorators
+There are helpers for AuthProvider these are wrapped into decorators these are applied to action methods.
+Every decorator parameters correspond to method arguments with the equal name of the authenrication provider instance.
+```ts
+import { inRole, isAuthenticated, isResourceOwner } from 'inversify-express-utils';
+
+@controller("/")
+class TestController extends BaseHttpController {
+
+    @httpGet("isAuthenticated")
+    @isAuthenticated()
+    public async isAuthenticated() {
+        return this.ok("OK");
+    }
+
+    @httpGet("isResourceOwner")
+    @isResourceOwner("2301")
+    public async isResourceOwner() {
+        return this.ok("OK");
+    }
+
+    @httpGet("inRole")
+    @inRole("admin")
+    public async inRole() {
+        return this.ok("OK");
+    }
+}
+```
+
+#### Custom HttpContext access decorator
+if you need to define own access decorator that reuses the HttpContext reuse ```httpContextAccessDecoratorFactory```
+as it is in an example under.
+
+```ts
+import { httpContextAccessDecoratorFactory } from 'inversify-express-utils';
+
+function userExists (pass = true): any {
+    return httpContextAccessDecoratorFactory(async (context) => {
+        return (await context.user.isAuthenticated() && pass);
+    });
+}
+```
+
 ## BaseMiddleware
 
 Extending `BaseMiddleware` allow us to inject dependencies

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -142,7 +142,7 @@ export function isAuthenticated (pass = true): any {
             );
             const _isAuthenticated = (await context.user.isAuthenticated());
             if (_isAuthenticated && pass) {
-                return fn.call(this, _request, _response)
+                return fn.call(this, _request, _response);
             } else {
                 _response
                   .status(403)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { InversifyExpressServer } from "./server";
 import { controller, httpMethod, httpGet, httpPut, httpPost, httpPatch,
         httpHead, all, httpDelete, request, response, requestParam, queryParam,
-        requestBody, requestHeaders, cookies, next, principal, injectHttpContext } from "./decorators";
+        requestBody, requestHeaders, cookies, next, principal, injectHttpContext,
+        httpContextAccessDecoratorFactory, isAuthenticated, isResourceOwner, inRole } from "./decorators";
 import { TYPE } from "./constants";
 import { interfaces } from "./interfaces";
 import * as results from "./results";
@@ -13,6 +14,7 @@ import { HttpResponseMessage } from "./httpResponseMessage";
 import { StringContent } from "./content/stringContent";
 import { JsonContent } from "./content/jsonContent";
 import { HttpContent } from "./content/httpContent";
+
 
 export {
     getRouteInfo,
@@ -46,5 +48,9 @@ export {
     HttpContent,
     StringContent,
     JsonContent,
-    results
+    results,
+    httpContextAccessDecoratorFactory,
+    inRole,
+    isAuthenticated,
+    isResourceOwner
 };

--- a/test/auth_provider.test.ts
+++ b/test/auth_provider.test.ts
@@ -21,7 +21,7 @@ describe("AuthProvider", () => {
         done();
     });
 
-    xit("Should be able to access current user via HttpContext", (done) => {
+    it("Should be able to access current user via HttpContext", (done) => {
 
         interface SomeDependency {
             name: string;

--- a/test/auth_provider.test.ts
+++ b/test/auth_provider.test.ts
@@ -72,8 +72,8 @@ describe("AuthProvider", () => {
                 if (this.httpContext.user !== null) {
                     const email = this.httpContext.user.details.email;
                     const name = this._someDependency.name;
-                    const isAuthenticated = await this.httpContext.user.isAuthenticated();
-                    expect(isAuthenticated).eq(true);
+                    const _isAuthenticated = await this.httpContext.user.isAuthenticated();
+                    expect(_isAuthenticated).eq(true);
                     return `${email} & ${name}`;
                 }
             }
@@ -139,7 +139,7 @@ describe("AuthProvider", () => {
             @httpGet("/")
             @isAuthenticated()
             public async getTest() {
-                return this.ok("OK")
+                return this.ok("OK");
             }
         }
 


### PR DESCRIPTION
IsAuthenticated decorator has been created that is applied to route actions.

## Description
There is functionality that provides authorization functionality. There are examples in imperative way these show how to use it. But it likes configurable rules. Principal has also to provide its functionality in a declarative way by decorators. I have not also found an example of decorator usage  

## Related Issue
[inversify-express-utils - An example of a custom decorator. Cover the Principal functionality with decorators.](https://github.com/inversify/inversify-express-utils/issues/454)

## Motivation and Context
It will provide the functionality in a declarative style. The project will provide functionality by configurable rules. It is convenient and structural approach.

## How Has This Been Tested?
## Expected Behavior
```
  @httpGet('/acl/:_id')
  @permission('fetch_any_acl')
  private async acl (request: Request) {
    const hasAccess = await this.httpContext.user.isResourceOwner('fetch_any_acl')
    if (!hasAccess) {
      return this.json({ message: 'Forbidden' }, 403)
    }
    const userData = await this.userEntity.getFull(new ObjectId(request.params._id))

    return this.json(userData, 200)
  }
```
## Current Behavior
```
  @httpGet('/acl/:_id')
  @permission('fetch_any_acl')
  private async acl (request: Request) {
    const userData = await this.userEntity.getFull(new ObjectId(request.params._id))

    return this.json(userData, 200)
  }
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
