### PR TITLE
Set express dependency to ^4.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^2.8.3"
   },
   "dependencies": {
-    "express": "4.16.2",
+    "express": "^4.16.3",
     "http-status-codes": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Description
Set express version to ^4.16.3 to avoid dependency on an exact version.

## Related Issue
Not changing architecture, so not linking an issue.

## Motivation and Context
inversify-express-utils is used as a library in end projects which have their own express in dependencies. Sometimes end projects have newer dependency versions than libraries.

## How Has This Been Tested?
`npx gulp` passed on node 11 and node 8.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
