### PR TITLE
Some devDependencies should be dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/body-parser": "1.17.0",
     "@types/chai": "4.1.4",
     "@types/cookie-parser": "1.4.1",
-    "@types/express": "4.16.1",
     "@types/mocha": "5.2.3",
     "@types/prettyjson": "0.0.28",
     "@types/sinon": "7.0.5",
@@ -46,7 +45,6 @@
     "gulp-sourcemaps": "^2.6.2",
     "gulp-tslint": "8.1.3",
     "gulp-typescript": "5.0.0",
-    "inversify": "5.0.1",
     "mocha": "5.2.0",
     "moq.ts": "^2.7.3",
     "prettyjson": "1.2.1",
@@ -60,7 +58,9 @@
     "typescript": "^2.8.3"
   },
   "dependencies": {
+    "@types/express": "4.16.1",
     "express": "4.16.2",
-    "http-status-codes": "^1.3.0"
+    "http-status-codes": "^1.3.0",
+    "inversify": "5.0.1"
   }
 }


### PR DESCRIPTION
Two dependencies marked as devDependencies are in fact runtime dependencies.  Importing this module using a package manager such as pnpm fails due to the missing runtime dependencies.

## Description
package.json - moved 2 devDependencies to dependencies.

## Related Issue
[InversifyJS #1056](https://github.com/inversify/InversifyJS/issues/1056).

## Motivation and Context
Unable to import `inversify-express-utils` with `pnpm`.

## How Has This Been Tested?
Run the tests as part of the gulpfile.js.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.