### PR TITLE
Allow middlewares to be auto bound

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,7 +187,9 @@ export class InversifyExpressServer {
 
     private resolveMidleware(...middleware: interfaces.Middleware[]): express.RequestHandler[] {
         return middleware.map(middlewareItem => {
-            if (!this._container.isBound(middlewareItem)) {
+            if (!this._container.options.autoBindInjectable
+                    && !this._container.isBound(middlewareItem)
+                    || !this._container.get(middlewareItem)) {
                 return middlewareItem as express.RequestHandler;
             }
 


### PR DESCRIPTION
## Description
This PR allows the middleware to be resolved when `autoBindInjectables` is `true`, by checking the container options and getting the middleware instead of checking if it is bound.

## Motivation and Context
When creating the container with `autoBindInjectables: true`, and using middlewares without explicitly binding them, the middleware resolution fails because it is not bound at the time, and then the request errors because the class is used as a middleware.

## How Has This Been Tested?
A new test was created in `base_middleware.test.ts` which creates a Container with `autoBindInjectables` set to `true` and then using the middleware in a controller method

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
