### PR TITLE
inversify is a dependency, not devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4175,8 +4175,7 @@
     "inversify": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
-      "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==",
-      "dev": true
+      "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ=="
     },
     "invert-kv": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-tslint": "8.1.4",
     "gulp-typescript": "5.0.1",
-    "inversify": "5.0.1",
     "mocha": "6.2.0",
     "moq.ts": "^3.0.0",
     "prettyjson": "1.2.1",
@@ -64,6 +63,7 @@
   },
   "dependencies": {
     "express": "4.17.1",
-    "http-status-codes": "^1.3.2"
+    "http-status-codes": "^1.3.2",
+    "inversify": "5.0.1"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It looks like PR #274 somehow got dropped along the way. I rely on having this behavior, so I wanna make sure this change gets in (or there's a reasonable workaround).

From the original PR:

> Inverisfy is added to package.json as a devDependency, but is a [dependency]

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Having inversify as a dev-only dependency breaks pnpm package manager which builds its runtime dependency graph using dependency only.

In my case, this breaks TypeScript compilation due to types imported from inversify and used in the public interface -- but I believe this would also break runtime JS even with regular npm if you fell into the unusual case of depending on inversify-express-utils but not inversify.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Made the package.json change, re-ran npm install and ran the tests. They still pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
