### PR TITLE
Fix BaseController.ok on non string content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `BaseMiddleware.handler` to allow async handlers.
 - Updated `Middleware` to allow include any `ServiceIdentifier`.
+- Updated `JsonContent` with no generic.
 
 ### Fixed
+- Updated `BaseController.ok` to no longer return `text/plain` responses when non string content is passed.
 
 ## [6.4.10]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/supertest": "6.0.2",
         "@typescript-eslint/eslint-plugin": "8.20.0",
         "@typescript-eslint/parser": "8.20.0",
+        "body-parser": "1.20.3",
         "cookie-parser": "1.4.7",
         "eslint": "9.18.0",
         "eslint-config-prettier": "10.0.1",
@@ -2889,7 +2890,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -2914,7 +2914,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2923,8 +2922,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -3017,7 +3015,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3276,7 +3273,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3444,7 +3440,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3454,7 +3449,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -3502,8 +3496,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4651,7 +4644,6 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -4684,7 +4676,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -5811,7 +5802,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6021,7 +6011,6 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -6517,7 +6506,6 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -6805,8 +6793,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -6940,8 +6927,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7071,7 +7057,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7510,7 +7495,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -7658,7 +7642,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -7716,7 +7699,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/supertest": "6.0.2",
     "@typescript-eslint/eslint-plugin": "8.20.0",
     "@typescript-eslint/parser": "8.20.0",
+    "body-parser": "1.20.3",
     "cookie-parser": "1.4.7",
     "eslint": "9.18.0",
     "eslint-config-prettier": "10.0.1",

--- a/src/base_http_controller.ts
+++ b/src/base_http_controller.ts
@@ -79,10 +79,10 @@ export class BaseHttpController {
     return new StatusCodeResult(statusCode);
   }
 
-  protected json<T extends Record<string, unknown>>(
-    content: T | T[],
+  protected json(
+    content: unknown,
     statusCode: number = StatusCodes.OK,
-  ): JsonResult<T> {
+  ): JsonResult {
     return new JsonResult(content, statusCode);
   }
 

--- a/src/content/httpContent.ts
+++ b/src/content/httpContent.ts
@@ -1,5 +1,4 @@
 import type { OutgoingHttpHeaders } from 'node:http';
-import type { Readable } from 'node:stream';
 
 export abstract class HttpContent {
   private readonly _headers: OutgoingHttpHeaders = {};
@@ -8,7 +7,5 @@ export abstract class HttpContent {
     return this._headers;
   }
 
-  public abstract readAsync(): Promise<
-    string | Record<string, unknown> | Record<string, unknown>[] | Readable
-  >;
+  public abstract readAsync(): Promise<unknown>;
 }

--- a/src/content/jsonContent.ts
+++ b/src/content/jsonContent.ts
@@ -2,16 +2,14 @@ import { HttpContent } from './httpContent';
 
 const DEFAULT_MEDIA_TYPE: string = 'application/json';
 
-export class JsonContent<
-  T extends Record<string, unknown>,
-> extends HttpContent {
-  constructor(private readonly content: T | T[]) {
+export class JsonContent extends HttpContent {
+  constructor(private readonly content: unknown) {
     super();
 
     this.headers['content-type'] = DEFAULT_MEDIA_TYPE;
   }
 
-  public async readAsync(): Promise<T | T[]> {
+  public async readAsync(): Promise<unknown> {
     return this.content;
   }
 }

--- a/src/results/JsonResult.ts
+++ b/src/results/JsonResult.ts
@@ -2,11 +2,9 @@ import { JsonContent } from '../content/jsonContent';
 import { HttpResponseMessage } from '../httpResponseMessage';
 import type { IHttpActionResult } from '../interfaces';
 
-export class JsonResult<T extends Record<string, unknown>>
-  implements IHttpActionResult
-{
+export class JsonResult implements IHttpActionResult {
   constructor(
-    public readonly json: T | T[],
+    public readonly json: unknown,
     public readonly statusCode: number,
   ) {}
 
@@ -14,7 +12,7 @@ export class JsonResult<T extends Record<string, unknown>>
     const response: HttpResponseMessage = new HttpResponseMessage(
       this.statusCode,
     );
-    response.content = new JsonContent<T>(this.json);
+    response.content = new JsonContent(this.json);
 
     return response;
   }

--- a/src/results/OkNegotiatedContentResult.ts
+++ b/src/results/OkNegotiatedContentResult.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
+import { JsonContent } from '../content/jsonContent';
 import { StringContent } from '../content/stringContent';
 import { HttpResponseMessage } from '../httpResponseMessage';
 import type { IHttpActionResult } from '../interfaces';
@@ -11,7 +12,12 @@ export class OkNegotiatedContentResult<T> implements IHttpActionResult {
     const response: HttpResponseMessage = new HttpResponseMessage(
       StatusCodes.OK,
     );
-    response.content = new StringContent(JSON.stringify(this.content));
+
+    if (typeof this.content === 'string') {
+      response.content = new StringContent(this.content);
+    } else {
+      response.content = new JsonContent(this.content);
+    }
 
     return response;
   }

--- a/src/test/action_result.test.ts
+++ b/src/test/action_result.test.ts
@@ -41,9 +41,7 @@ describe('ActionResults', () => {
         await actionResult.executeAsync();
 
       expect(responseMessage.statusCode).toBe(StatusCodes.OK);
-      expect(await responseMessage.content.readAsync()).toBe(
-        JSON.stringify(content),
-      );
+      expect(await responseMessage.content.readAsync()).toStrictEqual(content);
     });
   });
 

--- a/src/test/content/jsonContent.test.ts
+++ b/src/test/content/jsonContent.test.ts
@@ -4,7 +4,7 @@ import { JsonContent } from '../../content/jsonContent';
 
 describe('JsonContent', () => {
   it('should have application/json as the default media type', () => {
-    const content: JsonContent<Record<string, unknown>> = new JsonContent({});
+    const content: JsonContent = new JsonContent({});
     expect(content.headers['content-type']).toBe('application/json');
   });
 

--- a/src/test/issues/issue_420.test.ts
+++ b/src/test/issues/issue_420.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import * as bodyParser from 'body-parser';
+import { Application, Request } from 'express';
+import { Container } from 'inversify';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { BaseHttpController } from '../../base_http_controller';
+import { controller, httpPut, request } from '../../decorators';
+import { InversifyExpressServer } from '../../server';
+import { cleanUpMetadata } from '../../utils';
+
+describe('Issue 420', () => {
+  beforeEach(() => {
+    cleanUpMetadata();
+  });
+
+  it('should work with no url params', async () => {
+    @controller('/controller')
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    class TestController extends BaseHttpController {
+      @httpPut('/test')
+      public async updateTest(
+        @request()
+        req: Request<unknown, unknown, { test: string }, void>,
+      ) {
+        return this.ok({ message: req.body.test });
+      }
+    }
+
+    const container: Container = new Container();
+
+    const server: InversifyExpressServer = new InversifyExpressServer(
+      container,
+    );
+
+    server.setConfig((app: Application) => {
+      app.use(
+        bodyParser.urlencoded({
+          extended: true,
+        }),
+      );
+      app.use(bodyParser.json());
+    });
+
+    const agent: TestAgent<supertest.Test> = supertest(server.build());
+
+    const response: supertest.Response = await agent
+      .put('/controller/test')
+      .send({ test: 'test' })
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual({ message: 'test' });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### Changed
- Updated `JsonContent` with no generic.

### Fixed
- Updated `BaseController.ok` to no longer return `text/plain` responses when non string content is passed.

## Related Issue
inversify/inversify-express-utils#420

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
